### PR TITLE
Parsing argument "rate" as clockrate in <simulate (Issue #147) (#475)

### DIFF
--- a/bathbot/src/commands/osu/simulate/args.rs
+++ b/bathbot/src/commands/osu/simulate/args.rs
@@ -41,7 +41,7 @@ impl SimulateArg {
             Some("acc" | "a" | "accuracy") => parse_acc(rest).map(SimulateArg::Acc),
             Some("bpm") => parse_bpm(rest).map(SimulateArg::Bpm),
             Some("combo" | "c") => parse_combo(rest).map(SimulateArg::Combo),
-            Some("clockrate" | "cr") => parse_clock_rate(rest).map(SimulateArg::ClockRate),
+            Some("clockrate" | "cr" | "rate") => parse_clock_rate(rest).map(SimulateArg::ClockRate),
             Some("n300") => parse_n300(rest).map(SimulateArg::N300),
             Some("n100") => parse_n100(rest).map(SimulateArg::N100),
             Some("n50") => parse_n50(rest).map(SimulateArg::N50),
@@ -389,7 +389,20 @@ mod tests {
             SimulateArg::parse("123*"),
             Ok(SimulateArg::ClockRate(123.0))
         );
+        assert_eq!(
+            SimulateArg::parse("rate=123*"),
+            Ok(SimulateArg::ClockRate(123.0))
+        );
+        assert_eq!(
+            SimulateArg::parse("rate=123.0x"),
+            Ok(SimulateArg::ClockRate(123.0))
+        );
+        assert_eq!(
+            SimulateArg::parse("rate=123.0"),
+            Ok(SimulateArg::ClockRate(123.0))
+        );
         assert_eq!(SimulateArg::parse("cr=123%"), Err(ParseError::ClockRate));
+        assert_eq!(SimulateArg::parse("rate=123%"), Err(ParseError::ClockRate));
     }
 
     #[test]

--- a/bathbot/src/commands/osu/simulate/mod.rs
+++ b/bathbot/src/commands/osu/simulate/mod.rs
@@ -206,7 +206,7 @@ async fn simulate(ctx: Arc<Context>, orig: CommandOrigin<'_>, args: SimulateArgs
     Various arguments can be specified in multiple ways:\n\
     - Accuracy: `acc=[number]` or `[number]%`\n\
     - Combo: `combo=[integer]` or `[integer]x`\n\
-    - Clock rate: `clockrate=[number]` or `[number]*`\n\
+    - Clock rate: `clockrate=[number]` or `[number]*` or `rate=[number]`\n\
     - Bpm: `bpm=[number]` (only if clock rate is not specified)\n\
     - n300: `n300=[integer]` or `[integer]x300`\n\
     - n100: `n100=[interger]` or `[integer]x100`\n\
@@ -250,7 +250,7 @@ async fn prefix_simulate(
     Various arguments can be specified in multiple ways:\n\
     - Accuracy: `acc=[number]` or `[number]%`\n\
     - Combo: `combo=[integer]` or `[integer]x`\n\
-    - Clock rate: `clockrate=[number]` or `[number]*`\n\
+    - Clock rate: `clockrate=[number]` or `[number]*` or `rate=[number]`\n\
     - Bpm: `bpm=[number]` (only if clock rate is not specified)\n\
     - n300: `n300=[integer]` or `[integer]x300`\n\
     - n100: `n100=[interger]` or `[integer]x100`\n\
@@ -291,7 +291,7 @@ async fn prefix_simulatetaiko(
     Various arguments can be specified in multiple ways:\n\
     - Accuracy: `acc=[number]` or `[number]%`\n\
     - Combo: `combo=[integer]` or `[integer]x`\n\
-    - Clock rate: `clockrate=[number]` or `[number]*`\n\
+    - Clock rate: `clockrate=[number]` or `[number]*` or `rate=[number]`\n\
     - Bpm: `bpm=[number]` (only if clock rate is not specified)\n\
     - fruits: `n300=[integer]` or `[integer]x300`\n\
     - droplets: `n100=[interger]` or `[integer]x100`\n\
@@ -334,7 +334,7 @@ async fn prefix_simulatectb(
     Various arguments can be specified in multiple ways:\n\
     - Accuracy: `acc=[number]` or `[number]%`\n\
     - Combo: `combo=[integer]` or `[integer]x`\n\
-    - Clock rate: `clockrate=[number]` or `[number]*`\n\
+    - Clock rate: `clockrate=[number]` or `[number]*` or `rate=[number]`\n\
     - Bpm: `bpm=[number]` (only if clock rate is not specified)\n\
     - n320: `n320=[integer]` or `[integer]x320`\n\
     - n300: `n300=[integer]` or `[integer]x300`\n\


### PR DESCRIPTION
* Parsing argument "rate" as clockrate in <simulate